### PR TITLE
Add requirements Python for Windows 10 enviroment

### DIFF
--- a/full/src/requirements.txt
+++ b/full/src/requirements.txt
@@ -1,0 +1,12 @@
+PyQt5
+cryptography
+certifi
+paramiko
+altgraph
+pywin32-ctypes
+pyinstaller-hooks-contrib
+pefile
+packaging
+pyinstaller
+pywin32
+pypiwin32


### PR DESCRIPTION
Dear All. 
That requirement file when build udsclient in windows 10 64bit