### PR TITLE
Add module python win32crypt in windows11

### DIFF
--- a/src/uds/os_detector.py
+++ b/src/uds/os_detector.py
@@ -37,6 +37,7 @@ def get_osname() -> types.OsType:
     if sys.platform.startswith('linux'):
         return types.OsType.LINUX
     if sys.platform.startswith('win'):
+    	import win32crypt
         return types.OsType.WINDOWS
     if sys.platform.startswith('darwin'):
         return types.OsType.MACOS


### PR DESCRIPTION
Dear @dkmstr 
This merge to hot fix bug: "Module win32crypt not found" 
Link issues:  https://github.com/VirtualCable/uds-client/issues/2 
Thanks for review