### PR TITLE
GitHub actions

### DIFF
--- a/.github/UDSClient.nsi
+++ b/.github/UDSClient.nsi
@@ -1,0 +1,28 @@
+!define VERSION 1.0.0
+
+Name "UDSClient"
+OutFile "openUDS-Client_Installer-${VERSION}.exe"
+InstallDir "$PROGRAMFILES\UDSClient"
+Page Directory
+Page InstFiles
+Section
+  SetOutPath $INSTDIR
+  File /nonfatal /a /r "UDSClient\"
+
+  WriteRegStr HKCR "uds" "" "URL:UDS Protocol"
+  WriteRegStr HKCR "uds" "URL Protocol" ""
+  WriteRegStr HKCR "uds\shell\open\command" "" '"$INSTDIR\UDSClient.exe" "%1"'
+
+  WriteRegStr HKCR "udss" "" "URL:UDS Protocol SSL"
+  WriteRegStr HKCR "udss" "URL Protocol" ""
+  WriteRegStr HKCR "udss\shell\open\command" "" '"$INSTDIR\UDSClient.exe" "%1"'
+
+  WriteUninstaller $INSTDIR\uninstaller.exe
+SectionEnd
+
+Section "Uninstall"
+
+Delete $INSTDIR\uninstaller.exe
+
+RMDir /r $INSTDIR
+SectionEnd

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,0 +1,84 @@
+name: Build UDSClient exe installer
+on:
+  push:
+    branches: [ master, v4.0 ]
+  pull_request:
+    branches: [ master, v4.0 ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: powershell
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-win64.txt
+
+    - name: Build Picture to Icon
+      run: |
+        cd src
+        pyside6-rcc -o .\UDSResources_rc.py .\UDSResources.qrc
+
+    - name: Create PyInstaller Spec File
+      run: |
+        cd src
+        pyi-makespec --onefile --paths="c:\hostedtoolcache\windows\python\3.10.11\x64\lib\site-packages" --hidden-import=win32crypt --hidden-import=certifi --windowed UDSClient.py
+
+    - name: Generate PyInstaller build
+      run: |
+        cd src
+        pyinstaller --noconfirm UDSClient.spec
+
+    - name: Extract version from Python file
+      run: |
+        $lines = Get-Content src/uds/consts.py
+        foreach ($line in $lines) {
+          if ($line -match "VERSION:\s*\S+\s*=\s*'([\d\.]+)'") {
+            $version = $matches[1]
+            echo "VERSION=$version" >> $env:GITHUB_ENV
+            break
+          }
+        }
+        if (-not $version) {
+          throw "VERSION not found in consts.py"
+        }
+
+    - name: Install NSIS
+      run: |
+        choco install nsis -y
+        echo "C:\Program Files (x86)\NSIS" >> $env:GITHUB_PATH
+
+    - name: Prepare files for installer
+      run: |
+        New-Item -ItemType Directory -Path src\UDSClient
+        Copy-Item src\dist\UDSClient.exe -Destination src\UDSClient\
+
+    - name: Patch .nsi with version
+      run: |
+        $nsi = Get-Content .github/UDSClient.nsi
+        $nsi = $nsi -replace '!define VERSION .*', "!define VERSION ${{ env.VERSION }}"
+        Set-Content src/UDSClient.nsi $nsi
+
+    - name: Build NSIS Installer
+      run: |
+        cd src
+        makensis UDSClient.nsi
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: UDSClient-installers-${{ env.VERSION }}-${{ github.sha }}
+        path: src\openUDS-Client_Installer-${{ env.VERSION }}.exe

--- a/BUILD-Windows.md
+++ b/BUILD-Windows.md
@@ -131,7 +131,7 @@ Change the path where you store your source code on line 7 to:
                 <RegistryKey Root="HKCR" Key="uds">
                     <RegistryValue Type="string" Name="URL Protocol" Value="" />
                 </RegistryKey>
-                <RegistryValue Root="HKCR" Key="udss\shell\open\command" Type="string" Value='"[INSTALLFOLDER]\[ProductName]\[ProductName]exe" %1' />
+                <RegistryValue Root="HKCR" Key="udss\shell\open\command" Type="string" Value='"[INSTALLFOLDER]\[ProductName]\[ProductName].exe" %1' />
                 <RegistryValue Root="HKCR" Key="udss" Type="string"  Value='URL:Uds Protocol SSL' />
                 <RegistryKey Root="HKCR" Key="udss">
                     <RegistryValue Type="string" Name="URL Protocol" Value="" />

--- a/BUILD-Windows.md
+++ b/BUILD-Windows.md
@@ -30,6 +30,10 @@ Open Command Prompt (CMD) and execute the following commands:
 ```
     pyrcc5 -o .\UDSResources_rc.py .\UDSResources.qrc
 ```
+or
+```
+    pyside6-rcc -o .\UDSResources_rc.py .\UDSResources.qrc
+```
 
 ## Create PyInstaller Spec File
 

--- a/BUILD-Windows.md
+++ b/BUILD-Windows.md
@@ -131,7 +131,7 @@ Change the path where you store your source code on line 7 to:
             <Component Id="VDIClientComponent" Guid="{77f76869-ba64-4853-8758-6b262cdfc0e3}">          
                 <File Id="VDIClientEXE" Source="!(wix.UDSCLIENTDIR)\uds-client\src\dist\UDSClient.exe" KeyPath="yes" />
                 <RegistryValue Root="HKCR" Key="uds\shell\open\command" Type="string"  Value='"[INSTALLFOLDER]\[ProductName]\[ProductName].exe" %1' />
-                <RegistryValue Root="HKCR" Key="uds" Type="string"  Value='URL:Uds Protocol SSL' />
+                <RegistryValue Root="HKCR" Key="uds" Type="string"  Value='URL:Uds Protocol' />
                 <RegistryKey Root="HKCR" Key="uds">
                     <RegistryValue Type="string" Name="URL Protocol" Value="" />
                 </RegistryKey>


### PR DESCRIPTION
Using GitHub Actions instead of manual build.
By accepting these commits, you can get a ready to use .exe installer for windows.
At the moment, the build will be triggered by a commit or pull request to the master or v4.0 branches. If necessary, this behavior can be changed.
I decided to use NSIS instead of WiX Toolset because it is a more flexible tool. It also allows you to create installers more easily. And also at the output we get the installer, which also has the uninstall function, which is necessary for the correct and complete removal of the program, which is not present in .the msi that was created using the readme.
And also the documentation has been slightly corrected.