### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,4 +1,6 @@
 name: Build UDSClient exe installer
+permissions:
+  contents: read
 on:
   push:
     branches: [ master, v4.0 ]


### PR DESCRIPTION
Potential fix for [https://github.com/VirtualCable/uds-client/security/code-scanning/7](https://github.com/VirtualCable/uds-client/security/code-scanning/7)

To fix the problem, add a `permissions` field at the workflow or job level to specify the minimum required permissions for the workflow’s `GITHUB_TOKEN`. In this workflow, none of the actions seem to require write permissions—there are no steps creating PRs, modifying issues, or pushing to the repository. The only potential use of permissions is downloading/uploading artifacts, but that utilizes the `actions/upload-artifact` action, which does not need elevated permissions beyond the default. Therefore, setting `permissions: { contents: read }` at the workflow’s root (just below the `name`) is the correct and minimal fix. This follows least-privilege principles and satisfies the security recommendation.  
You only need to add the following block (with correct YAML indentation) after the `name` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
