### PR TITLE
fix: add udslauncher.xml to the installation files

### DIFF
--- a/building/linux/udslauncher.spec
+++ b/building/linux/udslauncher.spec
@@ -42,3 +42,4 @@ cp -a %{DESTDIR}/* %{buildroot}/
 %files
 /usr/share/udslauncher
 /usr/share/applications/udslauncher.desktop
+/usr/share/mime/packages/udslauncher.xml


### PR DESCRIPTION
This pull request adds a new file entry to the package specification for `udslauncher`. The change ensures that the `udslauncher.xml` MIME package is included when the package is built and installed.

This solve this problem in build:
`/usr/bin/add-determinism --brp -j16 /crate/building/linux/rpm-fedora/BUILD/udslauncher-devel-build/BUILDROOT
error: Installed (but unpackaged) file(s) found:
/usr/share/mime/packages/udslauncher.xml
Installed (but unpackaged) file(s) found:
/usr/share/mime/packages/udslauncher.xml
cp: cannot stat '/home/andres/work/Github/builds/client/uds-client/building/linux/rpm-fedora/RPMS/x86_64/udslauncher-*.rpm': No such file or directory`

The error occurs when rpmbuild (the RPM packaging tool) detects that during the package installation process (e.g., in the %install phase within the "BUILDROOT"), a file was copied or created, but that file wasn't explicitly declared in the %files section of the .spec file.

In this particular case, it's the file with the MIME type (link associations and extension):
`udslauncher.xml`

* Packaging update:
  * Added `/usr/share/mime/packages/udslauncher.xml` to the `%files` section in `udslauncher.spec`, ensuring the MIME package is installed with the application.