### PR TITLE
fix(rdp): wrap rdp content in dict for rdp_signature POST

### DIFF
--- a/src/uds/rest.py
+++ b/src/uds/rest.py
@@ -178,7 +178,7 @@ class RestApi:
         try:
             data = self.request(
                 '/{}/rdp_signature'.format(ticket),
-                data=json.dumps(rdp_data),
+                data=json.dumps({'rdp': rdp_data}),
                 params={'hostname': tools.gethostname(), 'version': consts.VERSION},
             )
         except Exception as e:


### PR DESCRIPTION
This pull request makes a small update to the `request_rdp_sign` method in `src/uds/rest.py` to adjust the format of the data sent in the request. Instead of sending the RDP data as a raw string, it is now wrapped in a dictionary under the key `'rdp'`.