### PR TITLE
fix(gui): scale progress bar value to 0.0-1.0 range

### DIFF
--- a/crates/gui/src/window/client_progress.rs
+++ b/crates/gui/src/window/client_progress.rs
@@ -104,7 +104,7 @@ impl AppWindow {
         state: ProgressState,
     ) {
         let elapsed = state.start.elapsed().as_secs_f32();
-        let progress = state.progress.load(std::sync::atomic::Ordering::Relaxed) as f32;
+        let progress = state.progress.load(std::sync::atomic::Ordering::Relaxed) as f32 / 100.0;
         egui::CentralPanel::default().show_inside(ui, |ui| {
             ui.add_space(30.0);
             ui.horizontal_centered(|ui| {


### PR DESCRIPTION
This pull request makes a minor adjustment to the progress calculation in the `AppWindow` implementation. The progress value is now divided by 100.0, likely to convert it from a percentage (0-100) to a normalized value (0.0-1.0) for display or further computation.

Root cause: progress was stored as a u16 in the 0..100 range but passed directly to egui::ProgressBar::new, which expects 0.0..1.0. Any non-zero value was clamped to 100%.                                                               
           
  Fix: divide the stored value by 100 before passing it to the progress bar, so the actual percentage reported by the server (e.g. 75%) is displayed correctly.

* Normalize progress value by dividing by 100.0 in the `AppWindow` progress calculation (`crates/gui/src/window/client_progress.rs`).

*DEV Explain*
When launching a connection and the client/server cannot yet reach the target VM (IP change, service still preparing, etc.), the broker returns a retryable error with a percent field (e.g. 75%). The UDS Launcher was always rendering this as 100% in the progress bar.